### PR TITLE
Corrected typos in CMakeLists.txt

### DIFF
--- a/src/line_follower/CMakeLists.txt
+++ b/src/line_follower/CMakeLists.txt
@@ -164,8 +164,8 @@ include_directories(
    ${catkin_LIBRARIES}
  )
 
- add_dependencies(drive_bot line_follower_genrate_messages_cpp)
- add_dependencies(line_follower line_follower_genrate_messages_cpp)
+ add_dependencies(drive_bot line_follower_generate_messages_cpp)
+ add_dependencies(line_follower line_follower_generate_messages_cpp)
 
 
 #############


### PR DESCRIPTION
There were some typo issues in CMakeLists.txt of the line_follower package which has been solved.